### PR TITLE
Fixed the first parameter of substations

### DIFF
--- a/input/release_v_9_0_0/35_2D_Vajont_experiment/2D_Vajont_experiment.inp
+++ b/input/release_v_9_0_0/35_2D_Vajont_experiment/2D_Vajont_experiment.inp
@@ -228,5 +228,5 @@ vtkconverter any 0.05
 ##### end section flow rate #####
 
 ##### substations #####
-0. 0.
+0 0.
 ##### end substations #####


### PR DESCRIPTION
Fixed the first parameter of substations, which should be an integer (i.e., 0.0 -> 0).