### PR TITLE
Fix compilation error caused by preprocessor variable in SPACE_3D

### DIFF
--- a/src/Post_processing/Memo_Results.f90
+++ b/src/Post_processing/Memo_Results.f90
@@ -93,11 +93,12 @@ if (index(str,'inizio')/=0) then
 #endif
    if (NumTratti>0) write(nres) Tratto(1:NumTratti)
    do i_zone=1,NPartZone
+      size_aux = 0
+#ifdef SPACE_3D
       if (allocated(Partz(i_zone)%BC_zmax_vertices)) then
          size_aux = size(Partz(i_zone)%BC_zmax_vertices,1)
-         else
-            size_aux = 0
       endif
+#endif
       write(nres) size_aux
       write(nres) Partz(i_zone)%DBSPH_fictitious_reservoir_flag,               &
          Partz(i_zone)%ipool,Partz(i_zone)%icol,                               &


### PR DESCRIPTION
'BC_zmax_vertices'  is valid only  if the 'SPACE_3D' is defined. Therefore, without this declaration, it will cause a compilation error.
Like this,
`Post_processing/Memo_Results.f90:96:50:

   96 |       if (allocated(Partz(i_zone)%BC_zmax_vertices)) then
      |                                                  1
Error: ‘bc_zmax_vertices’ at (1) is not a member of the ‘tyzone’ structure
Post_processing/Memo_Results.f90:97:55:

   97 |          size_aux = size(Partz(i_zone)%BC_zmax_vertices,1)
      |                                                       1
Error: ‘bc_zmax_vertices’ at (1) is not a member of the ‘tyzone’ structure
Post_processing/Memo_Results.f90:98:13:

   98 |          else
      |             1
Error: Unexpected ELSE statement at (1)
Post_processing/Memo_Results.f90:100:9:

  100 |       endif
      |         1
Error: Expecting END DO statement at (1)